### PR TITLE
Trim email address input whitespace

### DIFF
--- a/tests/appointment.test.js
+++ b/tests/appointment.test.js
@@ -240,10 +240,10 @@ async function bookAppointment(context, url, params, testInfo) {
         .evaluate((el, name) => (el.value = name), name),
       page
         .locator("input#email")
-        .evaluate((el, email) => (el.value = email), inbox.emailAddress),
+        .evaluate((el, email) => (el.value = email.trim()), inbox.emailAddress),
       page
         .locator("input#emailequality")
-        .evaluate((el, email) => (el.value = email), inbox.emailAddress),
+        .evaluate((el, email) => (el.value = email.trim()), inbox.emailAddress),
       page
         .locator('select[name="surveyAccepted"]')
         .selectOption(takeSurvey === "true" ? "1" : "0"),
@@ -311,7 +311,6 @@ async function bookAppointment(context, url, params, testInfo) {
       300_000,
       true
     );
-
     let verificationCode;
     if (/verifizieren/.exec(firstEmail.subject)) {
       verificationCode = /<h2>([0-9a-zA-Z]{6})<\/h2>/.exec(firstEmail.body)[1];


### PR DESCRIPTION
For some reason, when setting the input element value for the email address and email address validation inputs, two whitespace characters are introduced.

These whitespace characters (leading) are trimmed for the email address input but not the validation input.

Therefore, this fix solves an error related to the email address inputs not matching after submission.