### PR TITLE
Use exact service name to prevent multiple matches

### DIFF
--- a/tests/appointment.test.js
+++ b/tests/appointment.test.js
@@ -77,6 +77,7 @@ async function getServiceURL(page, { serviceName }) {
       await page.goto(servicesURL, { waitUntil: "domcontentloaded" });
       const serviceLinkLocator = page.getByRole("link", {
         name: serviceName,
+        exact: true,
       });
       await expect(
         serviceLinkLocator,


### PR DESCRIPTION
Closes #19 