### PR TITLE
Fix typo in appointment verification button name

### DIFF
--- a/tests/appointment.test.js
+++ b/tests/appointment.test.js
@@ -390,7 +390,7 @@ async function bookAppointment(
       await expect(async () => {
         await Promise.all([
           page.waitForNavigation(),
-          page.getByRole("button", { name: "Termin verifzieren" }).click(),
+          page.getByRole("button", { name: "Termin verifizieren" }).click(),
         ]);
         await expect(
           page.getByRole("heading", { name: "Terminbestätigung" })


### PR DESCRIPTION
They've fixed a typo on service.berlin.de :)